### PR TITLE
Add GSheets Connection src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,311 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python,jetbrains,venv
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,jetbrains,venv
+
+### JetBrains ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+### venv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python,jetbrains,venv
+
+.streamlit/secrets.toml
+.streamlit/service_account_creds.json
+cli/.streamlit/secrets.toml
+/examples/.streamlit/secrets.toml
+/examples/.streamlit/service_account_creds.json
+*.db
+test-files/*
+*venv/*
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,130 @@
 # Streamlit GSheetsConnection
 
 Connect to public or private Google Sheets from your Streamlit app. Powered by `st.experimental_connection()` and [gspread](https://github.com/burnash/gspread).
+
+GSheets Connection works in two modes:
+* in Read Only mode, using publicly shared Spreadsheet URLs (Read Only mode)
+* CRUD operations support mode, with Authentication using Service Account. In order to use Service Account mode you need to enable Google Drive and Google Sheets API in [Google Developers Console](https://console.developers.google.com/).
+Follow **Initial setup for CRUD mode** section in order to authenticate your Streamlit app first.
+
+## Initial setup for CRUD mode
+
+1. Setup `.streamlit/secrets.toml` inside your Streamlit app root directory,  
+check out [Secret management documentation](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management) for references.
+2. [Enable API Access for a Project](https://docs.gspread.org/en/v5.7.1/oauth2.html#enable-api-access-for-a-project)
+    * Head to [Google Developers Console](https://console.developers.google.com/) and create a new project (or select the one you already have).
+    * In the box labeled “Search for APIs and Services”, search for “Google Drive API” and enable it.
+    * In the box labeled “Search for APIs and Services”, search for “Google Sheets API” and enable it.
+3. [Using Service Account](https://docs.gspread.org/en/v5.7.1/oauth2.html#for-bots-using-service-account)
+    * Enable API Access for a Project if you haven’t done it yet.
+    * Go to “APIs & Services > Credentials” and choose “Create credentials > Service account key”.
+    * Fill out the form
+    * Click “Create” and “Done”.
+    * Press “Manage service accounts” above Service Accounts.
+    * Press on ⋮ near recently created service account and select “Manage keys” and then click on “ADD KEY > Create new key”.
+    * Select JSON key type and press “Create”.
+
+You will automatically download a JSON file with credentials. It may look like this:
+```
+{
+    "type": "service_account",
+    "project_id": "api-project-XXX",
+    "private_key_id": "2cd … ba4",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nNrDyLw … jINQh/9\n-----END PRIVATE KEY-----\n",
+    "client_email": "473000000000-yoursisdifferent@developer.gserviceaccount.com",
+    "client_id": "473 … hd.apps.googleusercontent.com",
+    ...
+}
+```
+Remember the path to the downloaded credentials file. Also, in the next step you’ll need the value of client_email from this file.
+* **:red[Very important!]** Go to your spreadsheet and share it with a client_email from the step above. Just like you do with any other Google account. If you don’t do this, you’ll get a `gspread.exceptions.SpreadsheetNotFound` exception when trying to access this spreadsheet from your application or a script.
+
+4. Inside `streamlit/secrets.toml` place `service_account` configuration from downloaded JSON file, in the following format (where `gsheets` is your `st.connection` name):
+```
+# .streamlit/secrets.toml
+
+[connections.gsheets]
+spreadsheet = "<spreadsheet-name-or-url>"
+worksheet = "<worksheet-gid-or-folder-id>"  # worksheet GID is used when using Public Spreadsheet URL, when usign service_account it will be picked as folder_id
+type = ""  # leave empty when using Public Spreadsheet URL, when using service_account -> type = "service_account"
+project_id = ""
+private_key_id = ""
+private_key = ""
+client_email = ""
+client_id = ""
+auth_uri = ""
+token_uri = ""
+auth_provider_x509_cert_url = ""
+client_x509_cert_url = ""
+```
+
+## Publicly Shared Spreadsheet Example
+```python
+# example/st_app.py
+
+import streamlit as st
+from streamlit_gsheets import GSheetsConnection
+
+url = "https://docs.google.com/spreadsheets/d/1JDy9md2VZPz4JbYtRPJLs81_3jUK47nx6GYQjgU8qNY/edit?usp=sharing"
+
+conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+data = conn.read(spreadsheet=url, usecols=[0, 1])
+st.dataframe(data)
+```
+
+## Service Account Example
+
+```python
+# example/st_app_gsheets_using_service_account.py
+
+import streamlit as st
+from streamlit_gsheets import GSheetsConnection
+
+st.title("Read Google Sheet as DataFrame")
+
+conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+df = conn.read(worksheet="Example 1")
+
+st.dataframe(df)
+```
+
+```toml
+# .streamlit/secrets.toml
+
+[connections.gsheets]
+spreadsheet = "<spreadsheet-name-or-url>"
+worksheet = "<worksheet-gid-or-folder-id>"  # worksheet GID is used when using Public Spreadsheet URL, when usign service_account it will be picked as folder_id
+type = ""  # leave empty when using Public Spreadsheet URL, when using service_account -> type = "service_account"
+project_id = ""
+private_key_id = ""
+private_key = ""
+client_email = ""
+client_id = ""
+auth_uri = ""
+token_uri = ""
+auth_provider_x509_cert_url = ""
+client_x509_cert_url = ""
+```
+
+```txt
+# requirements.txt
+
+streamlit==1.22
+git+https://github.com/sfc-gh-jcarroll/st-connection-prpr.git#subdirectory=gsheets_connection
+pandasql  # this is for example/st_app.py only
+```
+
+**Note on install:** Streamlit 1.22 is not yet released; you can find a compatible .whl file
+[here](https://core-previews.s3-us-west-2.amazonaws.com/pr-6457/streamlit-1.21.0-py2.py3-none-any.whl).
+
+## Full example
+Check gsheets_connection/example directory for full example of the usage.
+
+## Q&A
+* > Does this work with a public spreadsheet without the authentication details? Or only a private spreadsheet?
+
+   GSheets Connection works in two modes:
+  * in Read Only mode, using publicly shared Spreadsheet URLs (Read Only mode)
+  * CRUD operations support mode, with Authentication using Service Account. In order to use Service Account mode you need to enable Google Drive and Google Sheets API in [Google Developers Console](https://console.developers.google.com/).
+  Follow **Initial setup for CRUD mode** section in order to authenticate your Streamlit app first.

--- a/examples/.streamlit/example.secrets.toml
+++ b/examples/.streamlit/example.secrets.toml
@@ -1,0 +1,15 @@
+# .streamlit/secrets.toml
+
+[connections.gsheets]
+spreadsheet = "<spreadsheet-name-or-url>"
+worksheet = "<worksheet-gid-or-folder-id>"  # worksheet GID is used when using Public Spreadsheet URL, when usign service_account it will be picked as folder_id
+type = ""  # leave empty when using Public Spreadsheet URL, when using service_account -> type = "service_account"
+project_id = ""
+private_key_id = ""
+private_key = ""
+client_email = ""
+client_id = ""
+auth_uri = ""
+token_uri = ""
+auth_provider_x509_cert_url = ""
+client_x509_cert_url = ""

--- a/examples/.streamlit/example.service_account_creds.json
+++ b/examples/.streamlit/example.service_account_creds.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "",
+  "private_key_id": "",
+  "private_key": "",
+  "client_email": "",
+  "client_id": "",
+  "auth_uri": "",
+  "token_uri": "",
+  "auth_provider_x509_cert_url": "",
+  "client_x509_cert_url": ""
+}

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,4 @@
+../../streamlit-1.21.0-py2.py3-none-any.whl
+# streamlit==1.22
+# git+https://github.com/sfc-gh-jcarroll/st-connection-prpr.git#subdirectory=gsheets_connection
+pandasql  # this is for examples/ only

--- a/examples/st_app.py
+++ b/examples/st_app.py
@@ -1,0 +1,40 @@
+import streamlit as st
+
+st.subheader("📗 Google Sheets st.connection using Public URLs")
+
+url = "https://docs.google.com/spreadsheets/d/1JDy9md2VZPz4JbYtRPJLs81_3jUK47nx6GYQjgU8qNY/edit?usp=sharing"
+
+st.write("#### 1. Read public Google Worksheet as Pandas")
+
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    df = conn.read(spreadsheet=url, usecols=[0, 1])
+    st.dataframe(df)
+
+st.write("#### 2. Query public Google Worksheet using SQL")
+st.info(
+    "Mutation SQL queries are in-memory only and do not results in the Worksheet update.",
+    icon="ℹ️",
+)
+st.warning(
+    """You can query only one Worksheet in provided public Spreadsheet,
+        use Worksheet name as target in from SQL queries.
+        The worksheet, which you query is defined by GID query parameter or GID parameters to query method.""",
+    icon="⚠️",
+)
+
+
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    df = conn.query(
+        'select births from "Example 2" limit 10', spreadsheet=url, usecols=[0, 1]
+    )
+    st.dataframe(df)

--- a/examples/st_app_gsheets_using_service_account.py
+++ b/examples/st_app_gsheets_using_service_account.py
@@ -1,0 +1,178 @@
+import streamlit as st
+import pandasql as psql
+
+st.subheader("📗 Google Sheets st.connection using Service Account")
+
+st.write("#### 1. API Reference")
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+    st.write(conn)
+    st.help(conn)
+
+st.write("#### 2. Initial setup")
+st.markdown(
+    """
+## Initial setup for CRUD mode
+
+1. Setup `.streamlit/secrets.toml` inside your Streamlit app root directory,  
+check out [Secret management documentation](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management) for references.
+2. [Enable API Access for a Project](https://docs.gspread.org/en/v5.7.1/oauth2.html#enable-api-access-for-a-project)
+    * Head to [Google Developers Console](https://console.developers.google.com/) and create a new project (or select the one you already have).
+    * In the box labeled “Search for APIs and Services”, search for “Google Drive API” and enable it.
+    * In the box labeled “Search for APIs and Services”, search for “Google Sheets API” and enable it.
+3. [Using Service Account](https://docs.gspread.org/en/v5.7.1/oauth2.html#for-bots-using-service-account)
+    * Enable API Access for a Project if you haven’t done it yet.
+    * Go to “APIs & Services > Credentials” and choose “Create credentials > Service account key”.
+    * Fill out the form
+    * Click “Create” and “Done”.
+    * Press “Manage service accounts” above Service Accounts.
+    * Press on ⋮ near recently created service account and select “Manage keys” and then click on “ADD KEY > Create new key”.
+    * Select JSON key type and press “Create”.
+
+You will automatically download a JSON file with credentials. It may look like this:
+```
+{
+    "type": "service_account",
+    "project_id": "api-project-XXX",
+    "private_key_id": "2cd … ba4",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nNrDyLw … jINQh/9\n-----END PRIVATE KEY-----\n",
+    "client_email": "473000000000-yoursisdifferent@developer.gserviceaccount.com",
+    "client_id": "473 … hd.apps.googleusercontent.com",
+    ...
+}
+```
+Remember the path to the downloaded credentials file. Also, in the next step you’ll need the value of client_email from this file.
+* **:red[Very important!]** Go to your spreadsheet and share it with a client_email from the step above. Just like you do with any other Google account. If you don’t do this, you’ll get a `gspread.exceptions.SpreadsheetNotFound` exception when trying to access this spreadsheet from your application or a script.
+
+4. Inside `streamlit/secrets.toml` place `service_account` configuration from downloaded JSON file, in the following format (where `gsheets` is your `st.connection` name):
+```
+# .streamlit/secrets.toml
+
+[connections.gsheets]
+spreadsheet = "<spreadsheet-name-or-url>"
+worksheet = "<worksheet-gid-or-folder-id>"  # worksheet GID is used when using Public Spreadsheet URL, when usign service_account it will be picked as folder_id
+type = ""  # leave empty when using Public Spreadsheet URL, when using service_account -> type = "service_account"
+project_id = ""
+private_key_id = ""
+private_key = ""
+client_email = ""
+client_id = ""
+auth_uri = ""
+token_uri = ""
+auth_provider_x509_cert_url = ""
+client_x509_cert_url = ""
+```
+"""
+)
+
+st.write("#### 3. Load DataFrame into Google Sheets")
+
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    # Create GSheets connection
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    # Demo Births DataFrame
+    df = psql.load_births()
+
+    # set create_spreadsheet to True to create spreadsheet,
+    # create_spreadsheet is False by default to avoid exceeding Google API Quota
+    create_spreadsheet = False
+
+    if create_spreadsheet:
+        df = conn.create(
+            worksheet="Example 1",
+            data=df,
+        )
+
+    # Display our Spreadsheet as st.dataframe
+    st.dataframe(df.head(10))
+
+st.write("#### 4. Read Google WorkSheet as DataFrame")
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    # Create GSheets connection
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    # Read Google WorkSheet as DataFrame
+    df = conn.read(
+        usecols=[
+            0,
+            1,
+        ],  # specify columns which you want to get, comment this out to get all columns
+    )
+
+    # Display our Spreadsheet as st.dataframe
+    st.dataframe(df)
+
+st.write("#### 5. Update Google WorkSheet using DataFrame")
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    # Create GSheets connection
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    # Demo Meat DataFrame
+    df = psql.load_meat()
+
+    # set update_spreadsheet to True to update spreadsheet,
+    # update_spreadsheet is False by default to avoid exceeding Google API Quota
+    update_spreadsheet = False
+
+    if update_spreadsheet:
+        df = conn.update(
+            worksheet="Example 1",
+            data=df,
+        )
+
+    # Display our Spreadsheet as st.dataframe
+    st.dataframe(df.head(10))
+
+st.write("#### 6. Query Google WorkSheet with SQL and get results as DataFrame")
+st.info(
+    "Mutation SQL queries are in-memory only and do not results in the Worksheet update.",
+    icon="ℹ️",
+)
+
+
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    # Create GSheets connection
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    # make sure worksheet name is in double quota "", in our case it's "Example 1"
+    # DuckDB SQL dialect is supported
+    sql = 'select * from "Example 1"'
+
+    df = conn.query(sql=sql, ttl=3600)
+
+    # Display our SQL query results as st.dataframe
+    st.dataframe(df.head(10))
+
+st.write("#### 7. Clear/delete worksheet")
+with st.echo():
+    import streamlit as st
+    from streamlit_gsheets import GSheetsConnection
+
+    # Create GSheets connection
+    conn = st.experimental_connection("gsheets", type=GSheetsConnection)
+
+    # set clear_worksheet to True to update spreadsheet,
+    # clear_worksheet is False by default to avoid exceeding Google API Quota
+    clear_worksheet = False
+
+    if clear_worksheet:
+        conn.clear(worksheet="Example 1")
+        # Uncomment this to delete worksheet Example 1
+        # conn.delete(spreadsheet=spreadsheet, worksheet="Example 1")
+        st.info("Worksheet Example 1 Cleared!")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+import setuptools
+
+VERSION = "0.0.1"  # PEP-440
+
+NAME = "streamlit_gsheets"
+
+INSTALL_REQUIRES = [
+    "streamlit>=1.21.0",
+    "gspread>=5.8.0",
+    "gspread-pandas>=3.2.2",
+    "gspread-dataframe>=3.3.0",
+    "gspread-formatting>=1.1.2",
+    "duckdb>=0.7.1",
+    "sql-metadata>=2.7.0",
+    "validators>=0.20.0",
+]
+
+
+setuptools.setup(
+    name=NAME,
+    version=VERSION,
+    description="Streamlit Connection for Google Sheets.",
+    url="https://github.com/sfc-gh-jcarroll/st-connection-prpr",
+    project_urls={
+        "Source Code": "https://github.com/sfc-gh-jcarroll/st-connection-prpr",
+    },
+    author="Tomasz Szerszeń",
+    author_email="tomasz.szerszen@snowflake.com",
+    license="Apache License 2.0",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Environment :: Console",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.10",
+    ],
+    # Snowpark requires Python 3.8
+    python_requires=">=3.8",
+    # Requirements
+    install_requires=INSTALL_REQUIRES,
+    packages=["streamlit_gsheets"],
+)

--- a/streamlit_gsheets/__init__.py
+++ b/streamlit_gsheets/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from streamlit_gsheets.gsheets_connection import GSheetsConnection

--- a/streamlit_gsheets/gsheets_connection.py
+++ b/streamlit_gsheets/gsheets_connection.py
@@ -1,0 +1,746 @@
+# Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+import duckdb
+from abc import ABC, abstractmethod
+from urllib.parse import urlparse
+from urllib.parse import parse_qs
+from datetime import timedelta
+from sql_metadata import Parser
+from typing import Union, Optional, List
+from pandas import DataFrame, read_csv
+from numpy import ndarray
+from gspread.client import Client as GSpreadClient
+from gspread.worksheet import Worksheet
+from gspread.spreadsheet import Spreadsheet
+from gspread import service_account_from_dict
+from streamlit.connections import ExperimentalBaseConnection
+from streamlit.runtime.caching import cache_data
+from validators.url import url as validate_url
+from validators.utils import ValidationFailure
+from streamlit.type_util import is_dataframe_compatible, convert_anything_to_df
+from gspread_dataframe import get_as_dataframe, set_with_dataframe
+from gspread_formatting.dataframe import (
+    format_with_dataframe as set_format_with_dataframe,
+)
+
+
+class GSheetsClient(ABC):
+    _client: Optional[GSpreadClient] = None
+    _spreadsheet: Optional[str] = None
+    _worksheet: Optional[str] = None
+
+    def __init__(self, secrets_dict: dict):
+        self._spreadsheet = secrets_dict.pop("spreadsheet", None)
+        self._worksheet = secrets_dict.pop("worksheet", None)
+        if secrets_dict.get("type", None) == "service_account":
+            self._client = service_account_from_dict(secrets_dict)
+
+    def set_default(
+        self,
+        spreadsheet: str,
+        *,  # keyword-only arguments:
+        worksheet: Optional[str] = None,
+    ):
+        self._spreadsheet = spreadsheet
+        self._worksheet = worksheet
+
+    @abstractmethod
+    def read(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def query(
+        self,
+        sql: str,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def create(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[str] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        raise NotImplementedError
+
+    @abstractmethod
+    def clear(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        folder_id: Optional[str] = None,
+    ) -> dict:
+        raise NotImplementedError
+
+
+class GSheetsServiceAccountClient(GSheetsClient):
+    def _open_spreadsheet(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        folder_id: Optional[str] = None,
+    ) -> Spreadsheet:
+        if type(spreadsheet) is Spreadsheet:
+            return spreadsheet
+
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not folder_id and self._worksheet:
+            folder_id = self._worksheet
+
+        try:
+            if validate_url(spreadsheet):
+                return self._client.open_by_url(url=spreadsheet)
+            else:
+                raise ValidationFailure(
+                    "spreadsheet is not URL", args={"spreadsheet": spreadsheet}
+                )
+        except ValidationFailure:
+            return self._client.open(title=spreadsheet, folder_id=folder_id)
+
+    def _select_worksheet(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        folder_id: Optional[str] = None,
+    ) -> Worksheet:
+        if type(worksheet) is Worksheet:
+            return worksheet
+
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not folder_id and self._worksheet:
+            folder_id = self._worksheet
+
+        if type(spreadsheet) is str:
+            spreadsheet = self._open_spreadsheet(
+                spreadsheet=spreadsheet, folder_id=folder_id
+            )
+
+        if type(worksheet) is str:
+            return spreadsheet.worksheet(worksheet)
+        if not worksheet:
+            worksheet = 0
+        return spreadsheet.get_worksheet(worksheet)
+
+    def read(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not folder_id and self._worksheet:
+            folder_id = self._worksheet
+
+        @cache_data(ttl=ttl, max_entries=max_entries)
+        def _get_as_dataframe(
+            spreadsheet, folder_id, worksheet, evaluate_formulas, **options
+        ):
+            return get_as_dataframe(
+                worksheet=self._select_worksheet(
+                    spreadsheet=spreadsheet, folder_id=folder_id, worksheet=worksheet
+                ),
+                evaluate_formulas=evaluate_formulas,
+                **options,
+            )
+
+        return _get_as_dataframe(
+            spreadsheet,
+            folder_id,
+            worksheet,
+            evaluate_formulas,
+            **options,
+        )
+
+    def query(
+        self,
+        sql: str,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not folder_id and self._worksheet:
+            folder_id = self._worksheet
+
+        @cache_data(ttl=ttl, max_entries=max_entries)
+        def _query(sql, spreadsheet, folder_id, evaluate_formulas, **options):
+            in_memory_db = duckdb.connect()
+            for worksheet in Parser(sql).tables:
+                df = DataFrame()
+                create_table_sql = f'CREATE TABLE "{worksheet}" AS SELECT * FROM df'
+                if not self._select_worksheet(
+                    spreadsheet=spreadsheet, folder_id=folder_id, worksheet=worksheet
+                ):
+                    in_memory_db.sql(create_table_sql)
+                    _ = df
+                    continue
+                df = self.read(
+                    spreadsheet=spreadsheet,
+                    folder_id=folder_id,
+                    worksheet=worksheet,
+                    ttl=ttl,
+                    max_entries=max_entries,
+                    evaluate_formulas=evaluate_formulas,
+                    **options,
+                )
+                in_memory_db.sql(create_table_sql)
+                _ = df
+            return in_memory_db.sql(query=sql).to_df()
+
+        return _query(sql, spreadsheet, folder_id, evaluate_formulas, **options)
+
+    def create(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[str] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not folder_id and self._worksheet:
+            folder_id = self._worksheet
+
+        spreadsheet = self._client.create(title=spreadsheet, folder_id=folder_id)
+        worksheet = spreadsheet.add_worksheet(title=worksheet, rows=1000, cols=26)
+
+        if is_dataframe_compatible(data) or type(data) is ndarray:
+            if is_dataframe_compatible(data):
+                data = convert_anything_to_df(data)
+            elif type(data) is ndarray:
+                data = DataFrame.from_records(data)
+            set_with_dataframe(worksheet, data)
+            set_format_with_dataframe(worksheet, data, include_column_header=True)
+        return data
+
+    def update(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not folder_id and self._worksheet:
+            folder_id = self._worksheet
+
+        if type(spreadsheet) is str:
+            spreadsheet = self._open_spreadsheet(
+                spreadsheet=spreadsheet, folder_id=folder_id
+            )
+
+        worksheet = self._select_worksheet(
+            spreadsheet=spreadsheet, folder_id=folder_id, worksheet=worksheet
+        )
+
+        if is_dataframe_compatible(data) or type(data) is ndarray:
+            if is_dataframe_compatible(data):
+                data = convert_anything_to_df(data)
+            elif type(data) is ndarray:
+                data = DataFrame.from_records(data)
+            if worksheet:
+                self.clear(
+                    spreadsheet=spreadsheet,
+                    folder_id=folder_id,
+                    worksheet=worksheet,
+                )
+            set_with_dataframe(worksheet, data)
+            set_format_with_dataframe(worksheet, data, include_column_header=True)
+        return data
+
+    def clear(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        folder_id: Optional[str] = None,
+    ) -> dict:
+        return self._select_worksheet(
+            spreadsheet=spreadsheet, worksheet=worksheet, folder_id=folder_id
+        ).clear()
+
+
+class UnsupportedOperationException(Exception):
+    pass
+
+
+class GSheetsPublicSpreadsheetClient(GSheetsClient):
+    def _get_download_as_csv_url(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: str,
+        worksheet: Optional[str] = None,
+    ) -> str:
+        validation_failure = ValidationFailure(
+            "spreadsheet validation failure",
+            args={"spreadsheet": spreadsheet},
+        )
+        try:
+            if validate_url(spreadsheet):
+                r = re.compile(r"\/d\/.+?(?=\/)")
+                found_ids = r.findall(spreadsheet)
+                if len(found_ids) < 1:
+                    raise validation_failure
+                key = found_ids[0][3:]
+                parsed_url = urlparse(spreadsheet)
+                parsed_qs = parse_qs(parsed_url.query)
+                frag = parsed_url.fragment
+                gid_re = re.compile(r"gid=\w+")
+                found_gids = gid_re.findall(frag)
+                final_gid = None
+                if len(found_gids) > 0:
+                    final_gid = found_gids[0][4:]
+                elif parsed_qs.get("gid", []) and len(parsed_qs.get("gid", [])) > 0:
+                    final_gid = parsed_qs.get("gid", [""])[0]
+                if worksheet:
+                    final_gid = worksheet
+                url = f"https://docs.google.com/spreadsheet/ccc?key={key}&output=csv"
+                if final_gid:
+                    return f"{url}&gid={final_gid}"
+                return url
+            else:
+                raise validation_failure
+        except (ValidationFailure, TypeError):
+            url = (
+                f"https://docs.google.com/spreadsheet/ccc?key={spreadsheet}&output=csv"
+            )
+            if worksheet:
+                return f"{url}&gid={worksheet}"
+            return url
+
+    def read(
+        self,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not worksheet and self._worksheet:
+            worksheet = self._worksheet
+        url = self._get_download_as_csv_url(
+            spreadsheet=spreadsheet, worksheet=worksheet
+        )
+
+        @cache_data(ttl=ttl, max_entries=max_entries)
+        def _get_as_dataframe(url: str, **options) -> DataFrame:
+            return read_csv(url, **options)
+
+        return _get_as_dataframe(url, **options)
+
+    def query(
+        self,
+        sql: str,
+        *,  # keyword-only arguments:
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        if not spreadsheet and self._spreadsheet:
+            spreadsheet = self._spreadsheet
+        if not worksheet and self._worksheet:
+            worksheet = self._worksheet
+        url = self._get_download_as_csv_url(
+            spreadsheet=spreadsheet, worksheet=worksheet
+        )
+
+        @cache_data(ttl=ttl, max_entries=max_entries)
+        def _query(sql: str, url: str, **options):
+            in_memory_db = duckdb.connect()
+            for worksheet in Parser(sql).tables:
+                df = read_csv(url, **options)
+                create_table_sql = f'CREATE TABLE "{worksheet}" AS SELECT * FROM df'
+                in_memory_db.sql(create_table_sql)
+                _ = df
+            return in_memory_db.sql(query=sql).to_df()
+
+        return _query(sql, url, **options)
+
+    def create(
+        self,
+        *,
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[str] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        raise UnsupportedOperationException(
+            "Use Service Account authentication to enable CRUD methods on your Spreadsheets."
+        )
+
+    def update(
+        self,
+        *,
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        raise UnsupportedOperationException(
+            "Public Spreadsheet cannot be written to, "
+            "use Service Account authentication to enable CRUD methods on your Spreadsheets."
+        )
+
+    def clear(
+        self,
+        *,
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        folder_id: Optional[str] = None,
+    ):
+        raise UnsupportedOperationException(
+            "Public Spreadsheet cannot be cleared, "
+            "use Service Account authentication to enable CRUD methods on your Spreadsheets."
+        )
+
+
+class GSheetsConnection(ExperimentalBaseConnection[GSheetsClient], GSheetsClient):
+    def _connect(self, **kwargs) -> GSheetsClient:
+        """Reads st.connection .streamlit/secrets.toml and returns GSheets
+        client based on them."""
+        secrets_dict = self._secrets.to_dict()
+        if secrets_dict.get("type", None) == "service_account":
+            return GSheetsServiceAccountClient(secrets_dict)
+        return GSheetsPublicSpreadsheetClient(secrets_dict)
+
+    @property
+    def client(self) -> GSheetsClient:
+        """Returns GSheets client instance."""
+        return self._instance
+
+    def read(
+        self,
+        *,
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        """Returns the worksheet contents as a DataFrame.
+
+        Parameters
+        ------------
+        spreadsheet: str:
+            When you're using Service Account its spreadsheet name, otherwise its public spreadsheet URL.
+            Defaults to None. If None .streamlit/secrets.toml spreadsheet variable is used.
+        worksheet: str or int
+            When you're using Public Spreadsheet URL its GID of Worksheet you'd like to read.
+            When you're using Service Account its worksheet name or worksheet index.
+            Defaults to None. If none .streamlit/secrets.toml worksheet variable is used.
+        evaluate_formulas: bool
+            When you're using Public Spreadsheet URL evaluate_formulas is ignored.
+            When you're using Service Account if True, get the value of a cell after formula evaluation,
+            otherwise get the formula itself if present. Defaults to True.
+        ttl : float or timedelta or None
+            The maximum number of seconds to keep an entry in the cache, or
+            None if cache entries should not expire. The default is None.
+            Note that ttl is incompatible with ``persist="disk"`` - ``ttl`` will be
+            ignored if ``persist`` is specified. Defaults to 3600 (1 hour).
+        max_entries : int or None
+            The maximum number of entries to keep in the cache, or None
+            for an unbounded cache. (When a new entry is added to a full cache,
+            the oldest cached entry will be removed.) The default is None.
+        folder_id: Google API Folder id, Optional
+            Optional folder_id where your spreadsheet resides.
+        options: "pandas.io.parsers.TextParser"
+            All the options for pandas.io.parsers.TextParser,
+                according to the version of pandas that is installed.
+                (Note: TextParser supports only the default 'python' parser engine,
+                not the C engine.
+
+        Returns
+        -----------
+        df: pandas.DataFrame.
+        """
+        return self.client.read(
+            spreadsheet=spreadsheet,
+            worksheet=worksheet,
+            ttl=ttl,
+            max_entries=max_entries,
+            evaluate_formulas=evaluate_formulas,
+            folder_id=folder_id,
+            **options,
+        )
+
+    def query(
+        self,
+        sql: str,
+        *,
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[Union[int, str]] = None,
+        ttl: Optional[Union[int, timedelta, None]] = 3600,
+        max_entries: Optional[Union[int, None]] = None,
+        evaluate_formulas: bool = True,
+        folder_id: Optional[str] = None,
+        **options,
+    ) -> DataFrame:
+        """Run SQL query against spreadsheet. Worksheet name should be used as
+        Table name inside double quotes. Use Worksheet name as target in SQL
+        queries. When using Public Spreadsheet URL you can only select
+        worksheet using GID passed as worksheet parameter.
+
+        For example: select * from "Example 1" limit 10
+
+        Parameters
+        ------------
+        sql: str:
+            SQL query which will query your spreadsheet.
+        spreadsheet: str:
+            When you're using Service Account its spreadsheet name, otherwise its public spreadsheet URL.
+            Defaults to None. If None .streamlit/secrets.toml spreadsheet variable is used.
+        worksheet: str or int
+            When you're using Public Spreadsheet URL its GID of Worksheet you'd like to read.
+            When you're using Service Account its worksheet name or worksheet index.
+            Defaults to None. If none .streamlit/secrets.toml worksheet variable is used.
+        evaluate_formulas: bool
+            When you're using Public Spreadsheet URL evaluate_formulas is ignored.
+            When you're using Service Account if True, get the value of a cell after formula evaluation,
+            otherwise get the formula itself if present. Defaults to True.
+        ttl : float or timedelta or None
+            The maximum number of seconds to keep an entry in the cache, or
+            None if cache entries should not expire. The default is None.
+            Note that ttl is incompatible with ``persist="disk"`` - ``ttl`` will be
+            ignored if ``persist`` is specified. Defaults to 3600 (1 hour).
+        max_entries : int or None
+            The maximum number of entries to keep in the cache, or None
+            for an unbounded cache. (When a new entry is added to a full cache,
+            the oldest cached entry will be removed.) The default is None.
+        folder_id: Google API Folder id, Optional
+            Optional folder_id where your spreadsheet resides.
+        options: "pandas.io.parsers.TextParser"
+            All the options for pandas.io.parsers.TextParser,
+                according to the version of pandas that is installed.
+                (Note: TextParser supports only the default 'python' parser engine,
+                not the C engine.
+
+        Returns
+        -----------
+        df: pandas.DataFrame.
+        """
+        return self.client.query(
+            sql=sql,
+            spreadsheet=spreadsheet,
+            worksheet=worksheet,
+            ttl=ttl,
+            max_entries=max_entries,
+            evaluate_formulas=evaluate_formulas,
+            folder_id=folder_id,
+            **options,
+        )
+
+    def create(
+        self,
+        *,
+        spreadsheet: Optional[str] = None,
+        worksheet: Optional[str] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        """Creates Google Worksheet and initializes it with provided data.
+
+        Parameters
+        ------------
+        spreadsheet: str:
+            When you're using Service Account its spreadsheet name, otherwise its public spreadsheet URL.
+            Defaults to None. If None .streamlit/secrets.toml spreadsheet variable is used.
+        worksheet: str or int
+            When you're using Public Spreadsheet URL its GID of Worksheet you'd like to read.
+            When you're using Service Account its worksheet name or worksheet index.
+            Defaults to None. If none .streamlit/secrets.toml worksheet variable is used.
+        data: DataFrame | ndarray | List[list] | List[dict]
+            Your worksheet will be populated with provided Data.
+            Supports DataFrame or data which is DataFrame compatible
+            (will be converted to DataFrame on the fly).
+        folder_id: Google API Folder id, Optional
+            Optional folder_id where your spreadsheet resides.
+
+        Returns
+        -----------
+        df: pandas.DataFrame.
+        """
+        return self.client.create(
+            spreadsheet=spreadsheet, worksheet=worksheet, data=data, folder_id=folder_id
+        )
+
+    def update(
+        self,
+        *,
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        data: Optional[Union[DataFrame, ndarray, List[list], List[dict]]] = None,
+        folder_id: Optional[str] = None,
+    ) -> DataFrame:
+        """Updates Google Worksheet with provided data.
+
+        Parameters
+        ------------
+        spreadsheet: str:
+            When you're using Service Account its spreadsheet name, otherwise its public spreadsheet URL.
+            Defaults to None. If None .streamlit/secrets.toml spreadsheet variable is used.
+        worksheet: str or int
+            When you're using Public Spreadsheet URL its GID of Worksheet you'd like to read.
+            When you're using Service Account its worksheet name or worksheet index.
+            Defaults to None. If none .streamlit/secrets.toml worksheet variable is used.
+        data: DataFrame | ndarray | List[list] | List[dict]
+            Your worksheet will be populated with provided Data.
+            Supports DataFrame or data which is DataFrame compatible
+            (will be converted to DataFrame on the fly).
+        folder_id: Google API Folder id, Optional
+            Optional folder_id where your spreadsheet resides.
+
+        Returns
+        -----------
+        df: pandas.DataFrame.
+        """
+        return self.client.update(
+            spreadsheet=spreadsheet, worksheet=worksheet, data=data, folder_id=folder_id
+        )
+
+    def clear(
+        self,
+        *,
+        spreadsheet: Optional[Union[str, Spreadsheet]] = None,
+        worksheet: Optional[Union[str, int, Worksheet]] = None,
+        folder_id: Optional[str] = None,
+    ) -> dict:
+        """Clears a worksheet from a spreadsheet.
+
+        Parameters
+        ------------
+        spreadsheet: str:
+            When you're using Service Account its spreadsheet name, otherwise its public spreadsheet URL.
+            Defaults to None. If None .streamlit/secrets.toml spreadsheet variable is used.
+        worksheet: str or int
+            When you're using Public Spreadsheet URL its GID of Worksheet you'd like to read.
+            When you're using Service Account its worksheet name or worksheet index.
+            Defaults to None. If none .streamlit/secrets.toml worksheet variable is used.
+        folder_id: Google API Folder id, Optional
+            Optional folder_id where your spreadsheet resides.
+
+
+        Return
+        -----------
+        response: dict
+            Google API GSpread clear response.
+        """
+        return self.client.clear(
+            spreadsheet=spreadsheet, worksheet=worksheet, folder_id=folder_id
+        )
+
+    def set_default(
+        self,
+        spreadsheet: str,
+        *,  # keyword-only arguments:
+        worksheet: Optional[str] = None,
+    ):
+        """Sets default spreadsheet and worksheet, if spreadsheet/worksheet
+        values were defined in .streamlit/secrets.toml overrides them.
+
+        Parameters
+        ------------
+        spreadsheet: str:
+            When you're using Service Account its spreadsheet name, otherwise its public spreadsheet URL.
+            Defaults to None. If None .streamlit/secrets.toml spreadsheet variable is used.
+        worksheet: str or int
+            When you're using Public Spreadsheet URL its GID of Worksheet you'd like to read.
+            When you're using Service Account its worksheet name or worksheet index.
+            Defaults to None. If none .streamlit/secrets.toml worksheet variable is used.
+        """
+        return self.client.set_default(spreadsheet=spreadsheet, worksheet=worksheet)
+
+    def _repr_html_(self) -> str:
+        module_name = getattr(self, "__module__", None)
+        class_name = type(self).__name__
+        if self._connection_name:
+            name = f"`{self._connection_name}` "
+            if len(self._secrets) > 0:
+                cfg = f"""- Configured from `[connections.{self._connection_name}]`
+                """
+            else:
+                cfg = ""
+        else:
+            name = ""
+            cfg = ""
+        md = f"""
+        ---
+        **st.connection {name}built from `{module_name}.{class_name}`**
+        {cfg}
+        - Learn more using `st.help()`
+        ---
+        """
+        return md


### PR DESCRIPTION
# Streamlit GSheetsConnection

Connect to public or private Google Sheets from your Streamlit app. Powered by `st.experimental_connection()` and [gspread](https://github.com/burnash/gspread).

GSheets Connection works in two modes:
* in Read Only mode, using publicly shared Spreadsheet URLs (Read Only mode)
* CRUD operations support mode, with Authentication using Service Account. In order to use Service Account mode you need to enable Google Drive and Google Sheets API in [Google Developers Console](https://console.developers.google.com/).
Follow **Initial setup for CRUD mode** section in order to authenticate your Streamlit app first.

## Initial setup for CRUD mode

1. Setup `.streamlit/secrets.toml` inside your Streamlit app root directory,  
check out [Secret management documentation](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/connect-to-data-sources/secrets-management) for references.
2. [Enable API Access for a Project](https://docs.gspread.org/en/v5.7.1/oauth2.html#enable-api-access-for-a-project)
    * Head to [Google Developers Console](https://console.developers.google.com/) and create a new project (or select the one you already have).
    * In the box labeled “Search for APIs and Services”, search for “Google Drive API” and enable it.
    * In the box labeled “Search for APIs and Services”, search for “Google Sheets API” and enable it.
3. [Using Service Account](https://docs.gspread.org/en/v5.7.1/oauth2.html#for-bots-using-service-account)
    * Enable API Access for a Project if you haven’t done it yet.
    * Go to “APIs & Services > Credentials” and choose “Create credentials > Service account key”.
    * Fill out the form
    * Click “Create” and “Done”.
    * Press “Manage service accounts” above Service Accounts.
    * Press on ⋮ near recently created service account and select “Manage keys” and then click on “ADD KEY > Create new key”.
    * Select JSON key type and press “Create”.

You will automatically download a JSON file with credentials. It may look like this:
```
{
    "type": "service_account",
    "project_id": "api-project-XXX",
    "private_key_id": "2cd … ba4",
    "private_key": "-----BEGIN PRIVATE KEY-----\nNrDyLw … jINQh/9\n-----END PRIVATE KEY-----\n",
    "client_email": "473000000000-yoursisdifferent@developer.gserviceaccount.com",
    "client_id": "473 … hd.apps.googleusercontent.com",
    ...
}
```
Remember the path to the downloaded credentials file. Also, in the next step you’ll need the value of client_email from this file.
* **Very important!** Go to your spreadsheet and share it with a client_email from the step above. Just like you do with any other Google account. If you don’t do this, you’ll get a `gspread.exceptions.SpreadsheetNotFound` exception when trying to access this spreadsheet from your application or a script.

4. Inside `streamlit/secrets.toml` place `service_account` configuration from downloaded JSON file, in the following format (where `gsheets` is your `st.connection` name):
```
# .streamlit/secrets.toml

[connections.gsheets]
spreadsheet = "<spreadsheet-name-or-url>"
worksheet = "<worksheet-gid-or-folder-id>"  # worksheet GID is used when using Public Spreadsheet URL, when usign service_account it will be picked as folder_id
type = ""  # leave empty when using Public Spreadsheet URL, when using service_account -> type = "service_account"
project_id = ""
private_key_id = ""
private_key = ""
client_email = ""
client_id = ""
auth_uri = ""
token_uri = ""
auth_provider_x509_cert_url = ""
client_x509_cert_url = ""
```

## Publicly Shared Spreadsheet Example
```python
# example/st_app.py

import streamlit as st
from streamlit_gsheets import GSheetsConnection

url = "https://docs.google.com/spreadsheets/d/1JDy9md2VZPz4JbYtRPJLs81_3jUK47nx6GYQjgU8qNY/edit?usp=sharing"

conn = st.experimental_connection("gsheets", type=GSheetsConnection)

data = conn.read(spreadsheet=url, usecols=[0, 1])
st.dataframe(data)
```

## Service Account Example

```python
# example/st_app_gsheets_using_service_account.py

import streamlit as st
from streamlit_gsheets import GSheetsConnection

st.title("Read Google Sheet as DataFrame")

conn = st.experimental_connection("gsheets", type=GSheetsConnection)
df = conn.read(worksheet="Example 1")

st.dataframe(df)
```

```toml
# .streamlit/secrets.toml

[connections.gsheets]
spreadsheet = "<spreadsheet-name-or-url>"
worksheet = "<worksheet-gid-or-folder-id>"  # worksheet GID is used when using Public Spreadsheet URL, when usign service_account it will be picked as folder_id
type = ""  # leave empty when using Public Spreadsheet URL, when using service_account -> type = "service_account"
project_id = ""
private_key_id = ""
private_key = ""
client_email = ""
client_id = ""
auth_uri = ""
token_uri = ""
auth_provider_x509_cert_url = ""
client_x509_cert_url = ""
```

```txt
# requirements.txt

streamlit==1.22
git+https://github.com/sfc-gh-jcarroll/st-connection-prpr.git#subdirectory=gsheets_connection
pandasql  # this is for example/st_app.py only
```

**Note on install:** Streamlit 1.22 is not yet released; you can find a compatible .whl file
[here](https://core-previews.s3-us-west-2.amazonaws.com/pr-6457/streamlit-1.21.0-py2.py3-none-any.whl).

## Full example
Check gsheets_connection/example directory for full example of the usage.

## Q&A
* > Does this work with a public spreadsheet without the authentication details? Or only a private spreadsheet?

   GSheets Connection works in two modes:
  * in Read Only mode, using publicly shared Spreadsheet URLs (Read Only mode)
  * CRUD operations support mode, with Authentication using Service Account. In order to use Service Account mode you need to enable Google Drive and Google Sheets API in [Google Developers Console](https://console.developers.google.com/).
  Follow **Initial setup for CRUD mode** section in order to authenticate your Streamlit app first.
