### PR TITLE
Pin validators to prevent breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ INSTALL_REQUIRES = [
     "gspread-formatting>=1.1.2",
     "duckdb>=0.7.1",
     "sql-metadata>=2.7.0",
-    "validators>=0.20.0",
+    "validators==0.20.0",
 ]
 
 


### PR DESCRIPTION
`validators` has introduced two breaking changes, first changing the parameters to initialize the `ValidationFailure` class, then renaming it to `ValidationError`.

This PR pins `validators==0.20.0` in `setup.py` to avoid the breaking change.