### PR TITLE
Update code to match with newest Validators version and fix Pandas 2.1 support by enforcing newest version of Duckdb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ INSTALL_REQUIRES = [
     "gspread-formatting>=1.1.2",
     "duckdb>=0.8.2.dev5002",
     "sql-metadata>=2.7.0",
-    "validators>=0.20.0",
+    "validators>=0.22.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "gspread-pandas>=3.2.2",
     "gspread-dataframe>=3.3.0",
     "gspread-formatting>=1.1.2",
-    "duckdb>=0.8.2.dev5154",
+    "duckdb>=0.8.2.dev4514",
     "sql-metadata>=2.7.0",
     "validators>=0.22.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "gspread-pandas>=3.2.2",
     "gspread-dataframe>=3.3.0",
     "gspread-formatting>=1.1.2",
-    "duckdb>=0.8.2.dev5002",
+    "duckdb>=0.8.2.dev4514",
     "sql-metadata>=2.7.0",
     "validators>=0.22.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-VERSION = "0.0.1"  # PEP-440
+VERSION = "0.0.2"  # PEP-440
 
 NAME = "streamlit_gsheets"
 
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "gspread-pandas>=3.2.2",
     "gspread-dataframe>=3.3.0",
     "gspread-formatting>=1.1.2",
-    "duckdb>=0.8.2.dev4514",
+    "duckdb>=0.8.2.dev5154",
     "sql-metadata>=2.7.0",
     "validators>=0.22.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ INSTALL_REQUIRES = [
     "gspread-pandas>=3.2.2",
     "gspread-dataframe>=3.3.0",
     "gspread-formatting>=1.1.2",
-    "duckdb>=0.8.2.dev4514",
+    "pandas>=1.3.0, <2",
+    "duckdb>=0.8.1",
     "sql-metadata>=2.7.0",
     "validators>=0.22.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ INSTALL_REQUIRES = [
     "gspread-pandas>=3.2.2",
     "gspread-dataframe>=3.3.0",
     "gspread-formatting>=1.1.2",
-    "duckdb>=0.7.1",
+    "duckdb>=0.8.2.dev5002",
     "sql-metadata>=2.7.0",
     "validators>=0.20.0",
 ]

--- a/streamlit_gsheets/gsheets_connection.py
+++ b/streamlit_gsheets/gsheets_connection.py
@@ -36,11 +36,7 @@ from streamlit.connections import ExperimentalBaseConnection
 from streamlit.runtime.caching import cache_data
 from streamlit.type_util import convert_anything_to_df, is_dataframe_compatible
 from validators.url import url as validate_url
-
-try:
-    from validators.utils import ValidationError as ValidationFailure
-except ImportError:
-    from validators.utils import ValidationFailure
+from validators.utils import ValidationError as ValidationFailure
 
 
 class GSheetsClient(ABC):

--- a/streamlit_gsheets/gsheets_connection.py
+++ b/streamlit_gsheets/gsheets_connection.py
@@ -36,7 +36,7 @@ from streamlit.connections import ExperimentalBaseConnection
 from streamlit.runtime.caching import cache_data
 from streamlit.type_util import convert_anything_to_df, is_dataframe_compatible
 from validators.url import url as validate_url
-from validators.utils import ValidationError as ValidationFailure
+from validators.utils import ValidationError
 
 
 class GSheetsClient(ABC):
@@ -144,10 +144,10 @@ class GSheetsServiceAccountClient(GSheetsClient):
             if validate_url(spreadsheet):
                 return self._client.open_by_url(url=spreadsheet)
             else:
-                raise ValidationFailure(
+                raise ValidationError(
                     "spreadsheet is not URL", arg_dict={"spreadsheet": spreadsheet}
                 )
-        except ValidationFailure:
+        except ValidationError:
             return self._client.open(title=spreadsheet, folder_id=folder_id)
 
     def _select_worksheet(
@@ -367,7 +367,7 @@ class GSheetsPublicSpreadsheetClient(GSheetsClient):
         spreadsheet: str,
         worksheet: str | int | None = None,
     ) -> str:
-        validation_failure = ValidationFailure(
+        validation_failure = ValidationError(
             "spreadsheet validation failure",
             arg_dict={"spreadsheet": spreadsheet},
         )
@@ -396,7 +396,7 @@ class GSheetsPublicSpreadsheetClient(GSheetsClient):
                 return url
             else:
                 raise validation_failure
-        except (ValidationFailure, TypeError):
+        except (ValidationError, TypeError):
             url = (
                 f"https://docs.google.com/spreadsheet/ccc?key={spreadsheet}&output=csv"
             )

--- a/streamlit_gsheets/gsheets_connection.py
+++ b/streamlit_gsheets/gsheets_connection.py
@@ -36,7 +36,11 @@ from streamlit.connections import ExperimentalBaseConnection
 from streamlit.runtime.caching import cache_data
 from streamlit.type_util import convert_anything_to_df, is_dataframe_compatible
 from validators.url import url as validate_url
-from validators.utils import ValidationFailure
+
+try:
+    from validators.utils import ValidationError as ValidationFailure
+except ImportError:
+    from validators.utils import ValidationFailure
 
 
 class GSheetsClient(ABC):
@@ -145,7 +149,7 @@ class GSheetsServiceAccountClient(GSheetsClient):
                 return self._client.open_by_url(url=spreadsheet)
             else:
                 raise ValidationFailure(
-                    "spreadsheet is not URL", args={"spreadsheet": spreadsheet}
+                    "spreadsheet is not URL", arg_dict={"spreadsheet": spreadsheet}
                 )
         except ValidationFailure:
             return self._client.open(title=spreadsheet, folder_id=folder_id)
@@ -369,7 +373,7 @@ class GSheetsPublicSpreadsheetClient(GSheetsClient):
     ) -> str:
         validation_failure = ValidationFailure(
             "spreadsheet validation failure",
-            args={"spreadsheet": spreadsheet},
+            arg_dict={"spreadsheet": spreadsheet},
         )
         try:
             if validate_url(spreadsheet):  # type: ignore

--- a/streamlit_gsheets/gsheets_connection.py
+++ b/streamlit_gsheets/gsheets_connection.py
@@ -318,7 +318,7 @@ class GSheetsServiceAccountClient(GSheetsClient):
         if not folder_id and self._worksheet:
             folder_id = self._worksheet
 
-        if type(spreadsheet) is str:
+        if isinstance(spreadsheet, str):
             spreadsheet = self._open_spreadsheet(
                 spreadsheet=spreadsheet, folder_id=folder_id
             )


### PR DESCRIPTION
Current version of `gsheets-connection` is broken due to:

- newest version of `validators` package renamed its functions
- `duckdb` lost compatibility with `pandas>=2.1.0`

This PR addresses above problems by:

- Enforcing newest `validators` version in `setup.py` and changing the `gsheets-connection` code to support newest API (Kudos to @sfc-gh-dmatthews for finding last working version and the reason behind the failure in [the following commit](https://github.com/sfc-gh-dmatthews/gsheets-connection/commit/f491a008703de06f6378be44cbf0c98cda8ccf84).
-  Newest releases of `duckdb` support `pandas>=2.1.0` so I pinned with `>=` developer version of `duckdb` 

Also this PR introduced some minor linting fixes to keep compatibility with `ruff`.